### PR TITLE
Move alert to the bottom

### DIFF
--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatWindow.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/ChatWindow.tsx
@@ -79,6 +79,11 @@ const useClasses = makeStyles({
         alignSelf: 'end',
         ...shorthands.gap(tokens.spacingVerticalS),
     },
+    alerts: {
+        display: 'flex',
+        flexDirection: 'column',
+        ...shorthands.margin(0, '72px'),
+    },
 });
 
 export const ChatWindow: React.FC = () => {
@@ -99,7 +104,6 @@ export const ChatWindow: React.FC = () => {
 
     return (
         <div className={classes.root}>
-            {selectedTab !== 'chat' && <Alerts />}
             <div className={classes.header}>
                 <div className={classes.title}>
                     {!features[FeatureKeys.SimplifiedExperience].enabled && (
@@ -172,6 +176,9 @@ export const ChatWindow: React.FC = () => {
             </div>
             {selectedTab === 'chat' && <ChatRoom />}
             {selectedTab === 'documents' && <ChatResourceList chatId={selectedId} />}
+            {selectedTab !== 'chat' && <div className={classes.alerts}>
+                <Alerts />
+            </div>}
         </div>
     );
 };

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/plan-viewer/PlanStepCard.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/plan-viewer/PlanStepCard.tsx
@@ -82,10 +82,11 @@ interface PlanStepCardProps {
     step: Plan;
     enableEdits: boolean;
     enableStepDelete: boolean;
+    singleStepPlan: boolean;
     onDeleteStep: (index: number) => void;
 }
 
-export const PlanStepCard: React.FC<PlanStepCardProps> = ({ step, enableEdits, enableStepDelete, onDeleteStep }) => {
+export const PlanStepCard: React.FC<PlanStepCardProps> = ({ step, enableEdits, enableStepDelete, singleStepPlan, onDeleteStep }) => {
     const classes = useClasses();
     const [openDialog, setOpenDialog] = useState(false);
 
@@ -103,7 +104,7 @@ export const PlanStepCard: React.FC<PlanStepCardProps> = ({ step, enableEdits, e
                     <CardHeader
                         header={
                             <Body1>
-                                <b className={classes.header}>Step {(step.index as number) + 1} •</b> {step.skill_name}.
+                                <b className={classes.header}>Step {singleStepPlan ? '' : (step.index as number) + 1} •</b> {step.skill_name}.
                                 {step.name}
                                 <br />
                             </Body1>

--- a/samples/apps/copilot-chat-app/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
+++ b/samples/apps/copilot-chat-app/webapp/src/components/chat/plan-viewer/PlanViewer.tsx
@@ -140,6 +140,7 @@ export const PlanViewer: React.FC<PlanViewerProps> = ({ message, messageIndex, g
                         step={{ ...step, index }}
                         enableEdits={planState === PlanState.PlanApprovalRequired}
                         enableStepDelete={plan.steps.length > 1}
+                        singleStepPlan={plan.steps.length === 1}
                         onDeleteStep={onDeleteStep}
                     />
                 );


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
1. Move alerts to the bottom
![image](https://github.com/teresaqhoang/semantic-kernel/assets/12570346/e4ce4871-cb5a-4479-8a8b-b74b8fbf283d)
2. PlanViewer doesn't show step index for single-step plans
![image](https://github.com/teresaqhoang/semantic-kernel/assets/12570346/c2048655-4139-4c95-9a76-6eca1fc232ef)

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#dev-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
